### PR TITLE
Feature/add seeders

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,8 @@ DB_DATABASE=prueba_innclod
 DB_USERNAME=prueba_innclod
 DB_PASSWORD=prueba_innclod
 ```
+
+## User credentials
+
+email: test@test.com
+password: Test@123

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
+        $this->call([
+            UserSeeder::class,
+        ]);
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             TipTipoDocSeeder::class,
+            ProProcesoSeeder::class,
         ]);
 
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             UserSeeder::class,
+            TipTipoDocSeeder::class,
         ]);
 
     }

--- a/database/seeders/ProProcesoSeeder.php
+++ b/database/seeders/ProProcesoSeeder.php
@@ -12,6 +12,16 @@ class ProProcesoSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $procesos = [
+            ['PRO_PREFIJO' => 'INGC', 'PRO_NOMBRE' => 'Plan de Ingeniería Civil'],
+            ['PRO_PREFIJO' => 'INGE', 'PRO_NOMBRE' => 'Manual de Ingeniería Eléctrica'],
+            ['PRO_PREFIJO' => 'INGM', 'PRO_NOMBRE' => 'Informe de Ingeniería Mecánica'],
+            ['PRO_PREFIJO' => 'INGS', 'PRO_NOMBRE' => 'Protocolo de Ingeniería de Software'],
+            ['PRO_PREFIJO' => 'INGQ', 'PRO_NOMBRE' => 'Proyecto de Ingeniería Química'],
+        ];
+        
+        foreach ($procesos as $proceso) {
+            \App\Models\ProProceso::factory()->create($proceso);
+        }
     }
 }

--- a/database/seeders/TipTipoDocSeeder.php
+++ b/database/seeders/TipTipoDocSeeder.php
@@ -13,15 +13,16 @@ class TipTipoDocSeeder extends Seeder
     public function run(): void
     {
         $tiposDocumentos = [
-            ['TIP_PREFIJO' => 'INGC', 'TIP_NOMBRE' => 'Plan de Ingeniería Civil'],
-            ['TIP_PREFIJO' => 'INGE', 'TIP_NOMBRE' => 'Manual de Ingeniería Eléctrica'],
-            ['TIP_PREFIJO' => 'INGM', 'TIP_NOMBRE' => 'Informe de Ingeniería Mecánica'],
-            ['TIP_PREFIJO' => 'INGS', 'TIP_NOMBRE' => 'Protocolo de Ingeniería de Software'],
-            ['TIP_PREFIJO' => 'INGQ', 'TIP_NOMBRE' => 'Proyecto de Ingeniería Química'],
+            ['TIP_PREFIJO' => 'INS', 'TIP_NOMBRE' => 'Instructivo'],
+            ['TIP_PREFIJO' => 'MAN', 'TIP_NOMBRE' => 'Manual de Usuario'],
+            ['TIP_PREFIJO' => 'PROC', 'TIP_NOMBRE' => 'Procedimiento Operativo'],
+            ['TIP_PREFIJO' => 'POL', 'TIP_NOMBRE' => 'Política Interna'],
+            ['TIP_PREFIJO' => 'GUI', 'TIP_NOMBRE' => 'Guía de Implementación'],
         ];
         
-        foreach ($tiposDocumentos as $tipo) {
-            \App\Models\TipTipoDoc::factory()->create($tipo);
+        foreach ($tiposDocumentos as $tipoDocumento) {
+            \App\Models\TipTipoDoc::factory()->create($tipoDocumento);
         }
+        
     }
 }

--- a/database/seeders/TipTipoDocSeeder.php
+++ b/database/seeders/TipTipoDocSeeder.php
@@ -12,6 +12,16 @@ class TipTipoDocSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $tiposDocumentos = [
+            ['TIP_PREFIJO' => 'INGC', 'TIP_NOMBRE' => 'Plan de Ingeniería Civil'],
+            ['TIP_PREFIJO' => 'INGE', 'TIP_NOMBRE' => 'Manual de Ingeniería Eléctrica'],
+            ['TIP_PREFIJO' => 'INGM', 'TIP_NOMBRE' => 'Informe de Ingeniería Mecánica'],
+            ['TIP_PREFIJO' => 'INGS', 'TIP_NOMBRE' => 'Protocolo de Ingeniería de Software'],
+            ['TIP_PREFIJO' => 'INGQ', 'TIP_NOMBRE' => 'Proyecto de Ingeniería Química'],
+        ];
+        
+        foreach ($tiposDocumentos as $tipo) {
+            \App\Models\TipTipoDoc::factory()->create($tipo);
+        }
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        \App\Models\User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@test.com',
+            'password' => Hash::make("Test@123")
+        ]);
+    }
+}

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -39,13 +39,6 @@ defineProps({
                     class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
                     >Log in</Link
                 >
-
-                <Link
-                    v-if="canRegister"
-                    :href="route('register')"
-                    class="ml-4 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
-                    >Register</Link
-                >
             </template>
         </div>
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,10 +23,6 @@
                         <a href="{{ url('/home') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Home</a>
                     @else
                         <a href="{{ route('login') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Log in</a>
-
-                        @if (Route::has('register'))
-                            <a href="{{ route('register') }}" class="ml-4 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Register</a>
-                        @endif
                     @endauth
                 </div>
             @endif


### PR DESCRIPTION
# Pull Request Description

## Introduction
This Pull Request (PR) introduces three new database seeders for the application, aimed at populating initial data for the system's fundamental tables. These seeders will facilitate the setup of document types, process information, and user accounts.

## Changes

### Seeders
The changes include the addition of the following seeders:
- `TipTipoDocTableSeeder`: Populates the `tip_tipo_doc` table with predefined types of document identifiers and names.
- `ProProcesoTableSeeder`: Inserts predefined process types into the `pro_proceso` table.
- `UserTableSeeder`: Creates initial user records in the `users` table for application testing and administrative access.

### Document Types
The document types added via `TipTipoDocTableSeeder` are:
- Instructivo (Prefix: INS)
- Manual de Usuario (Prefix: MAN)
- Procedimiento Operativo (Prefix: PROC)
- Política Interna (Prefix: POL)
- Guía de Implementación (Prefix: GUI)

Each type is assigned a unique prefix to facilitate quick identification within the system.

### Process Types
The `ProProcesoTableSeeder` adds various process types with relevant prefixes that correspond to specific procedural documents or standards within the organization.

### User Seeder
`UserTableSeeder` establishes a default administrator account, granting full privileges for application management and facilitating the initial login and setup process.

## Purpose
The inclusion of these seeders is to ensure a smooth and uniform initial configuration for the application, particularly valuable in development, testing, and staging environments. They serve to establish a baseline for application data and reduce manual setup efforts.

## Usage
After merging the changes from this PR, run the following artisan command to seed the database:
```bash
php artisan db:seed
